### PR TITLE
Fixed error Encoding format (tmp) is not supported

### DIFF
--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -164,7 +164,7 @@ trait TransformableImage
             $this->resizeImage();
         }
 
-        $this->image->save();
+        $this->image->save(null,null,'png');
         $this->image->destroy();
     }
 


### PR DESCRIPTION
i was using this field in my project and every time i try to save they give me the error

Encoding format (tmp) is not supported

i made a small fix in transformImage adding new parameters :) 
