### PR TITLE
Minor compatibility update for Nova 5 / PHP 8.4

### DIFF
--- a/src/AdvancedImage.php
+++ b/src/AdvancedImage.php
@@ -59,7 +59,7 @@ class AdvancedImage extends Image
      *
      * @return void
      */
-    protected function fillAttribute(NovaRequest $request, $requestAttribute, $model, $attribute)
+    protected function fillAttribute(NovaRequest $request, $requestAttribute, $model, $attribute): array
     {
         if (empty($request->{$requestAttribute})) {
             return;


### PR DESCRIPTION
Just added a return type of array to fillAttribute to help resolve PHP 8.4 compatibility issues on Laravel 11 / Nova 5