### PR TITLE
Fix namespace of Gd

### DIFF
--- a/src/TransformableImage.php
+++ b/src/TransformableImage.php
@@ -4,7 +4,7 @@ namespace Marshmallow\AdvancedImage;
 
 use Illuminate\Http\UploadedFile;
 use Intervention\Image\Drivers\Imagick\Driver;
-use Intervention\Image\Drivers\GD\Driver as GDDriver;
+use Intervention\Image\Drivers\Gd\Driver as GDDriver;
 use Intervention\Image\ImageManager;
 
 trait TransformableImage


### PR DESCRIPTION
The incorrect case in the namespace was causing issues in our project. The official definition of the namespace in Intervention is `Gd` and not `GD`.