### PR TITLE
(fix) update fillAttribute method signature and return type

### DIFF
--- a/src/AdvancedImage.php
+++ b/src/AdvancedImage.php
@@ -59,10 +59,10 @@ class AdvancedImage extends Image
      *
      * @return void
      */
-    protected function fillAttribute(NovaRequest $request, $requestAttribute, $model, $attribute): void
+    protected function fillAttribute(NovaRequest $request, string $requestAttribute, object $model, string $attribute): mixed
     {
         if (empty($request->{$requestAttribute})) {
-            return;
+            return null;
         }
 
         $previousFileName = $model->{$attribute};


### PR DESCRIPTION
Changed the fillAttribute method to use explicit type hints for parameters and a mixed return type. The method now returns null instead of void when the request attribute is empty, improving type safety and clarity.