### PR TITLE
Fix error: fillAttribute must always return something

### DIFF
--- a/src/AdvancedImage.php
+++ b/src/AdvancedImage.php
@@ -73,7 +73,7 @@ class AdvancedImage extends Image
             Storage::disk($this->disk)->delete($previousFileName);
         }
 
-        return parent::fillAttribute($request, $requestAttribute, $model, $attribute)
+        return parent::fillAttribute($request, $requestAttribute, $model, $attribute);
     }
 
     public function setCustomCallback($customCallback)


### PR DESCRIPTION
This method has mixed as a return type, yet it can return void. This is not allowed.

```
(TypeError(code: 0): Marshmallow\\AdvancedImage\\AdvancedImage::fillAttribute(): Return value must be of type mixed, none returned at .../vendor/marshmallow/nova-advanced-image/src/AdvancedImage.php:77)
```

This pr fixes this.